### PR TITLE
Несколько сценариев и отказ от записи результатов

### DIFF
--- a/matlab_env/getScenarioSimOutData.asv
+++ b/matlab_env/getScenarioSimOutData.asv
@@ -1,4 +1,4 @@
-function [result, simLog] = getScenarioSimOutData(scenarios_file, scen_quan, reward_type, penalty, results_directory)
+function [result, simLog] = getScenarioSimOutData(scenarios_file, scen_quan, reward_type, penalty, result_directory)
 % Функция выполняет загрузку пула сценариев, выбор случайного,
 % моделирование процесса, расчета награды и возвращает 3-хмерный массив для
 % обучения с добавлением рассчитанной награды.
@@ -24,9 +24,12 @@ for scennum = size(scenarios, 2):-1:1
     % result_.A_state
     % result_.Reward
     result(scennum) = handleParsimResults(simoutput(scennum), reward_type, penalty);
-
+    
+    
+    
+    
     % Запись результатов испытания в файл
     simLog(scennum) = saveSampleResults(scenarios(scennum), result(scennum), ...
-                      simoutput(scennum), reward_type, results_directory);
+                      simoutput(scennum), reward_type, result_directory);
 end
 end

--- a/matlab_env/saveSampleResults.m
+++ b/matlab_env/saveSampleResults.m
@@ -9,7 +9,9 @@ simLog.reward_agent = get_reward(simoutputs, true, reward_type);
 % Записывается информция о работе агента (пусть будет): state, actions, reward
 simLog.result_agent = results;
 
-% Сохранение файла результатов с меткой времени
-save(results_directory + "simLog " + replace(datestr(datetime(now,'ConvertFrom','datenum')),':','-') + ".mat","simLog");
+if(results_directory ~= "")
+    % Сохранение файла результатов с меткой времени
+    save(results_directory + "simLog " + replace(datestr(datetime(now,'ConvertFrom','datenum')),':','-') + ".mat","simLog");
+end
 
 end


### PR DESCRIPTION
Можно отбирать и моделировать более одного сценария.
Чтобы не сохранять результаты, нужно просто указать на входе функции пустой путь "".
Аргументами по умолчанию займусь чуть позже.